### PR TITLE
Parasitic drag bugfix (degree trig functions)

### DIFF
--- a/src/Aerodynamics/parasitic_drag.jl
+++ b/src/Aerodynamics/parasitic_drag.jl
@@ -76,7 +76,7 @@ end
     xs = @. le[:,1] + wing.chords * xs_temp # Determine max. thickness x-coordinates in geometry frame
     ds = xs[2:end] - xs[1:end-1] # Compute differences between max. thickness x-coordinates between sections
     widths = @. wing.spans / cosd(wing.dihedrals) # Project planform span onto geometry based on dihedral angles
-    Λs = @. atan(ds, widths) # Now compute sweep angles at max. thickness locations
+    Λs = @. atand(ds, widths) # Now compute sweep angles at max. thickness locations
 
     # Average chord lengths for sections
     xs = (xs_temp[1:end-1] + xs_temp[2:end]) / 2
@@ -86,7 +86,7 @@ end
 end
 
 # Raymer form factor for wing, tail, strut, and pylon, 4th edition (Eq. 12.30). "_m" refers to corresonding values at (t/c)_max here.
-form_factor_wing(x_c_m, t_c_max, Λ_m) = (1 + 0.6t_c_max / x_c_m + 100t_c_max^4) * cos(Λ_m)^0.28
+form_factor_wing(x_c_m, t_c_max, Λ_m) = (1 + 0.6t_c_max / x_c_m + 100t_c_max^4) * cosd(Λ_m)^0.28
 
 """
     form_factor(wing :: Wing, M, num)
@@ -110,7 +110,7 @@ function wetted_area_drag_coefficient(wing :: Wing, x_tr, ρ, V, M, μ, S_ref, n
     mean_chords = @views (wing.chords[1:end-1] + wing.chords[2:end]) / 2
 
     # Wetted areas for integration over averaged chords
-    S_wets = mean_chords .* spans(wing) ./ cos.(dihedrals(wing))
+    S_wets = @. mean_chords * wing.spans / cosd(wing.dihedrals)
 
     K_fs = form_factor(wing, num) # Form factors
     fM = 1.34M^0.18  # Mach number correction

--- a/src/Geometry/AircraftGeometry/Wings/halfwing.jl
+++ b/src/Geometry/AircraftGeometry/Wings/halfwing.jl
@@ -137,7 +137,7 @@ spans(wing :: Wing) = wing.spans
 dihedrals(wing :: Wing) = wing.dihedrals
 
 """
-    sweeps(wing :: AbstractWing, w = 0.)
+    sweeps(wing :: Wing, w = 0.)
 
 Obtain the sweep angles (in radians) at the corresponding normalized chord length ratio ``w ∈ [0,1]``.
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -225,7 +225,7 @@ end
         area = 10.,
         aspect = 6.,
         taper = 1.0,
-        sweep = 0.,
+        sweep = 10.,
         w_sweep = 0.25,
     )
 
@@ -261,7 +261,7 @@ end
     )
 
     L_wing = avg_c # Length
-    Kf_wing = (1 + 0.6tbyc_r / xbyc_r + 100tbyc_r^4) * cos(Λ)^0.28 # Wing form factor
+    Kf_wing = (1 + 0.6tbyc_r / xbyc_r + 100tbyc_r^4) * cosd(Λ)^0.28 # Wing form factor
     fM_wing = 1.34M^0.18
 
     CD0_wing = parasitic_drag_coefficient(L_wing, x_tr, ρ, V, M, μ, S_ref, S_wet, Kf_wing, fM_wing)
@@ -289,6 +289,7 @@ end
     @test CD0_fuse ≈ parasitic_drag_coefficient(fuse, refs, x_tr)
 end
 
+# %%
 @testset "Vortex Lattice Method (Horseshoes, Incompressible) - NACA 0012 Tapered Wing" begin
     # Define wing
     wing = Wing(


### PR DESCRIPTION
This merge fixes the bug in parasitic drag computation for wings. Specifically, trigonometric methods for radians were not updated to their degree counterparts. Tests have been updated accordingly with non-zero sweep angle.