### PR TITLE
fix: bugs in cosine interpolation and NACA4 airfoil

### DIFF
--- a/src/Geometry/AircraftGeometry/Foils/naca_airfoils.jl
+++ b/src/Geometry/AircraftGeometry/Foils/naca_airfoils.jl
@@ -53,6 +53,15 @@ function naca4_coordinates(digits :: NTuple{4, <: Real}, n :: Integer, sharp_TE 
     end
     coords = [ [x_upper y_upper][end:-1:2,:];
                 x_lower y_lower             ]
+
+    # Calculate squared distance between adjacent points
+    dists = vec(sum(abs2, diff(coords, dims=1), dims=2))
+
+    # Keep the first point, and any subsequent point that is far enough away (> 1e-12)
+    keep_indices = [true; dists .> 1e-12]
+
+    # Filter out duplicate points
+    return coords[keep_indices, :]
 end
 
 """

--- a/src/Geometry/AircraftGeometry/Foils/naca_airfoils.jl
+++ b/src/Geometry/AircraftGeometry/Foils/naca_airfoils.jl
@@ -46,6 +46,10 @@ function naca4_coordinates(digits :: NTuple{4, <: Real}, n :: Integer, sharp_TE 
         # Lower surface
         x_lower = @. xs + thickness * sin(grads)
         y_lower = @. camber - thickness * cos(grads)
+
+        # Clamp x-coordinates to be at least 0.0 to prevent BoundsError in interpolation
+        x_upper = max.(0.0, x_upper)
+        x_lower = max.(0.0, x_lower)
     end
     coords = [ [x_upper y_upper][end:-1:2,:];
                 x_lower y_lower             ]

--- a/src/Tools/MathTools.jl
+++ b/src/Tools/MathTools.jl
@@ -138,7 +138,7 @@ end
 
 uniform_spacing(x1, x2, n) = range(x1, x2, length = n)
 linear_spacing(x_center, len, n :: Integer) = @. x_center + len * 0:1/(n-1):1
-cosine_spacing(x_center, diameter, n :: Integer = 40) = @. x_center + (diameter / 2) * cos(-π:π/(n-1):0)
+cosine_spacing(x_center, diameter, n :: Integer = 40) = x_center .+ (diameter / 2) .* cos.(range(-π, 0, length = n))
 
 function sine_spacing(x1, x2, n :: Integer = 40)
     d = x2 - x1


### PR DESCRIPTION
Fixes https://github.com/GodotMisogi/AeroFuse.jl/issues/124

To reproduce:

```julia
using AeroFuse

function get_cl(i)::Union{Float64, Nothing}
    foil = naca4((4,4,1,2), i)
    uniform = Uniform2D(1.0, 4.0)
    try
        system = solve_case(foil, uniform)
        return lift_coefficient(system)
    catch
        return nothing
    end
end

points = 20:300
results = map(get_cl, points)
foreach(zip(points, results)) do (p, r)
    println("$p: $r")
end
println("fail percent: $(count(isnothing, results) / length(points) * 100)%")
```
on main, failure rate is 48%
with 63f4901c6e3302573df05af79aa387e4734b5c50 and 4d577fda3069b3172e4e4eb0644b55006601adee the failure rate drops to ~6%
0f33942cfe2260d4d274c2e81d5af00cf21f46c2 should fully fix the issue.